### PR TITLE
Fix relation usages example

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -63,9 +63,11 @@ require "relaton"
 => true
 
 # Do not cache any entries retrieved
-db = Relaton.new(nil, nil)
+db = Relaton::Db.new(nil, nil)
+
 # Use only the global cache for any entries retrieved
-db = Relaton.new("global cache filename", nil)
+db = Relaton::Db.new("global cache filename", nil)
+
 # Use both a local and a global cache
 db = Relaton::Db.new("global cache filename", "local cache filename")
 [relaton] detecting backends:


### PR DESCRIPTION
In the readme it suggest to use `Relaton.new` to instantiate a new db instance, but it actually fails since `Relaton` Module doesn't have any `new` method in it, and `Relaton::Db` does. So, this PR updates the usages guide with valid example.