### PR TITLE
Add simple executable bin script

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "relaton"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+require "pry"
+Pry.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here


### PR DESCRIPTION
This commit adds a single bin script `bin/console`, which can be used to play around / experiment the gem in the development phase. Usages:

```sh
bin/console
```
